### PR TITLE
Add printing build logs on failure

### DIFF
--- a/.github/workflows/bob.yml
+++ b/.github/workflows/bob.yml
@@ -89,6 +89,9 @@ jobs:
         run: java -jar bob.jar --platform=${{ matrix.platform }} --architectures ${{ matrix.platform }} build --build-server=${{ inputs.build_server }} ${{ inputs.additonal_build_options }}
       - name: Bundle
         run: java -jar bob.jar --platform=${{ matrix.platform }} --architectures ${{ matrix.platform }} bundle ${{ inputs.additonal_bundle_options }}
+      - name: Print build log on failure
+        if: failure()
+        run: cat build/*/log.txt 2>/dev/null || echo "No log file found"
 
   build_with_bob_windows:
     strategy:
@@ -125,6 +128,10 @@ jobs:
         run: java -jar bob.jar --platform=${{ matrix.platform }} --architectures ${{ matrix.platform }} build --build-server=${{ inputs.build_server }} ${{ inputs.additonal_build_options }}
       - name: Bundle
         run: java -jar bob.jar --platform=${{ matrix.platform }} --architectures ${{ matrix.platform }} bundle ${{ inputs.additonal_bundle_options }}
+      - name: Print build log on failure
+        if: failure()
+        run: cat build/*/log.txt 2>/dev/null || echo "No log file found"
+        shell: bash
 
   # macOS is not technically needed for building, but we want to test bundling as well, since we're also testing the manifest merging
   build_with_bob_macos:
@@ -161,3 +168,6 @@ jobs:
         run: java -jar bob.jar --platform=${{ matrix.platform }} --architectures ${{ matrix.platform }} build --build-server=${{ inputs.build_server }} ${{ inputs.additonal_build_options }}
       - name: Bundle
         run: java -jar bob.jar --platform=${{ matrix.platform }} --architectures ${{ matrix.platform }} bundle ${{ inputs.additonal_bundle_options }}
+      - name: Print build log on failure
+        if: failure()
+        run: cat build/*/log.txt 2>/dev/null || echo "No log file found"


### PR DESCRIPTION
Added a "Print build log on failure" step to all three build jobs (Linux, Windows, macOS) in bob.yml.
When a build fails, the contents of build/*/log.txt are automatically printed, making it easier to diagnose build errors directly in the GitHub Actions logs without needing to reproduce the issue locally.
The step only triggers on failure (if: failure()), so it has no impact on successful runs.

Fixes https://github.com/defold/github-actions-common/issues/11