### PR TITLE
Added Android SDK/NDK action for better control over what's actually installed

### DIFF
--- a/.github/actions/android/README.md
+++ b/.github/actions/android/README.md
@@ -50,8 +50,9 @@ It also adds these directories to `PATH`:
 SDK root resolution:
 
 - If `android-sdk-root` is set, that path is used.
-- On GitHub-hosted runners, the action prefers the runner's existing Android SDK via `ANDROID_SDK_ROOT`, then `ANDROID_HOME`, then falls back to `$HOME/.android/sdk`.
-- On self-hosted runners, the default is `${{ runner.temp }}/android-sdk` to avoid multiple runners on the same machine mutating a shared SDK directory.
+- Otherwise, the default is `${{ runner.temp }}/android-sdk`.
+- Using a runner-temp SDK avoids mixing with preinstalled runner SDK contents and reduces version-skew issues between `sdkmanager`, command-line tools, and existing package metadata.
+- On self-hosted runners, this also avoids multiple runners on the same machine mutating a shared SDK directory by default.
 
 Caching notes:
 

--- a/.github/actions/android/README.md
+++ b/.github/actions/android/README.md
@@ -1,0 +1,81 @@
+# Setup Android SDK
+
+Composite GitHub Action that installs Android command-line tools, platform tools, a requested platform, build-tools, and NDK version. It restores and saves the SDK directory with `actions/cache` and exports Android-related environment variables for later steps.
+
+Use the action from `.github/actions/android`:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: actions/setup-java@v5
+    with:
+      distribution: temurin
+      java-version: "25"
+
+  - name: Set up Android SDK
+    uses: defold/github-actions-common/.github/actions/android@<ref>
+
+  - name: Verify tools
+    run: |
+      adb version
+      sdkmanager --list_installed
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `android-api-level` | `36` | Android platform API level to install. |
+| `android-build-tools` | `36.1.0` | Android build-tools version to install. |
+| `android-ndk` | `25.2.9519653` | Android NDK version to install. |
+| `android-sdk-root` | empty | SDK install root. If omitted, the action chooses a platform-appropriate default. |
+| `cache-key-suffix` | `v1` | Manual cache-busting suffix appended to the cache key. |
+
+## Behavior
+
+The action exports:
+
+- `ANDROID_HOME`
+- `ANDROID_SDK_ROOT`
+- `ANDROID_NDK_HOME`
+- `ANDROID_NDK_ROOT`
+
+It also adds these directories to `PATH`:
+
+- `<sdk>/platform-tools`
+- `<sdk>/cmdline-tools/latest/bin`
+- `<sdk>/build-tools/<version>`
+
+SDK root resolution:
+
+- If `android-sdk-root` is set, that path is used.
+- On GitHub-hosted runners, the action prefers the runner's existing Android SDK via `ANDROID_SDK_ROOT`, then `ANDROID_HOME`, then falls back to `$HOME/.android/sdk`.
+- On self-hosted runners, the default is `${{ runner.temp }}/android-sdk` to avoid multiple runners on the same machine mutating a shared SDK directory.
+
+Caching notes:
+
+- Cache keys include runner OS, runner architecture, API level, build-tools version, NDK version, and `cache-key-suffix`.
+- Separating the cache by architecture avoids sharing SDK contents between x64 and arm64 runners.
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: actions/setup-java@v5
+    with:
+      distribution: temurin
+      java-version: "21"
+
+  - name: Set up Android SDK
+    uses: defold/github-actions-common/.github/actions/android@<ref>
+    with:
+      android-api-level: "36"
+      android-build-tools: "36.1.0"
+      android-ndk: "25.2.9519653"
+
+  - name: Build
+    run: ./gradlew assembleDebug
+```

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -32,7 +32,6 @@ runs:
       env:
         INPUT_ANDROID_SDK_ROOT: ${{ inputs.android-sdk-root }}
         RUNNER_ARCH: ${{ runner.arch }}
-        RUNNER_ENVIRONMENT: ${{ runner.environment }}
         RUNNER_TEMP_DIR: ${{ runner.temp }}
       run: |
         set -euo pipefail
@@ -43,11 +42,7 @@ runs:
         NDK_VERSION="${{ inputs.android-ndk }}"
 
         if [ -z "${SDK_ROOT}" ]; then
-          if [ "${RUNNER_ENVIRONMENT}" = "github-hosted" ]; then
-            SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/.android/sdk}}"
-          else
-            SDK_ROOT="${RUNNER_TEMP_DIR}/android-sdk"
-          fi
+          SDK_ROOT="${RUNNER_TEMP_DIR}/android-sdk"
         fi
 
         echo "sdk-root=${SDK_ROOT}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -1,0 +1,152 @@
+name: Setup Android SDK
+description: Setup Android SDK, build-tools, and NDK with cache and exported env vars
+
+inputs:
+  android-api-level:
+    description: Android platform API level to install
+    required: false
+    default: "36"
+  android-build-tools:
+    description: Android build-tools version to install
+    required: false
+    default: "36.1.0"
+  android-ndk:
+    description: Android NDK version to install
+    required: false
+    default: "25.2.9519653"
+  android-sdk-root:
+    description: Android SDK installation root
+    required: false
+    default: ""
+  cache-key-suffix:
+    description: Optional suffix to bump cache generation manually
+    required: false
+    default: "v1"
+
+runs:
+  using: composite
+  steps:
+    - name: Compute Android paths
+      id: vars
+      shell: bash
+      env:
+        INPUT_ANDROID_SDK_ROOT: ${{ inputs.android-sdk-root }}
+        RUNNER_ARCH: ${{ runner.arch }}
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        RUNNER_TEMP_DIR: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+
+        SDK_ROOT="${INPUT_ANDROID_SDK_ROOT}"
+        API_LEVEL="${{ inputs.android-api-level }}"
+        BUILD_TOOLS="${{ inputs.android-build-tools }}"
+        NDK_VERSION="${{ inputs.android-ndk }}"
+
+        if [ -z "${SDK_ROOT}" ]; then
+          if [ "${RUNNER_ENVIRONMENT}" = "github-hosted" ]; then
+            SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/.android/sdk}}"
+          else
+            SDK_ROOT="${RUNNER_TEMP_DIR}/android-sdk"
+          fi
+        fi
+
+        echo "sdk-root=${SDK_ROOT}" >> "$GITHUB_OUTPUT"
+        echo "runner-arch=${RUNNER_ARCH}" >> "$GITHUB_OUTPUT"
+        echo "api-level=${API_LEVEL}" >> "$GITHUB_OUTPUT"
+        echo "build-tools=${BUILD_TOOLS}" >> "$GITHUB_OUTPUT"
+        echo "ndk-version=${NDK_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "ndk-root=${SDK_ROOT}/ndk/${NDK_VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Android SDK cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.vars.outputs.sdk-root }}
+        key: ${{ runner.os }}-${{ steps.vars.outputs.runner-arch }}-android-sdk-api-${{ steps.vars.outputs.api-level }}-buildtools-${{ steps.vars.outputs.build-tools }}-ndk-${{ steps.vars.outputs.ndk-version }}-${{ inputs.cache-key-suffix }}
+        restore-keys: |
+          ${{ runner.os }}-${{ steps.vars.outputs.runner-arch }}-android-sdk-api-${{ steps.vars.outputs.api-level }}-buildtools-${{ steps.vars.outputs.build-tools }}-ndk-
+          ${{ runner.os }}-${{ steps.vars.outputs.runner-arch }}-android-sdk-api-${{ steps.vars.outputs.api-level }}-buildtools-${{ steps.vars.outputs.build-tools }}-
+          ${{ runner.os }}-${{ steps.vars.outputs.runner-arch }}-android-sdk-api-${{ steps.vars.outputs.api-level }}-
+          ${{ runner.os }}-${{ steps.vars.outputs.runner-arch }}-android-sdk-
+
+    - name: Export Android environment variables
+      shell: bash
+      run: |
+        SDK_ROOT="${{ steps.vars.outputs.sdk-root }}"
+        NDK_ROOT="${{ steps.vars.outputs.ndk-root }}"
+        BUILD_TOOLS="${{ steps.vars.outputs.build-tools }}"
+
+        {
+          echo "ANDROID_HOME=${SDK_ROOT}"
+          echo "ANDROID_SDK_ROOT=${SDK_ROOT}"
+          echo "ANDROID_NDK_HOME=${NDK_ROOT}"
+          echo "ANDROID_NDK_ROOT=${NDK_ROOT}"
+        } >> "$GITHUB_ENV"
+
+        {
+          echo "${SDK_ROOT}/platform-tools"
+          echo "${SDK_ROOT}/cmdline-tools/latest/bin"
+          echo "${SDK_ROOT}/build-tools/${BUILD_TOOLS}"
+        } >> "$GITHUB_PATH"
+
+    - name: Set up Android SDK tools
+      uses: android-actions/setup-android@v3
+      with:
+        packages: ""
+
+    - name: Install requested Android SDK packages
+      shell: bash
+      env:
+        ANDROID_SDK_ROOT: ${{ steps.vars.outputs.sdk-root }}
+        ANDROID_API_LEVEL: ${{ steps.vars.outputs.api-level }}
+        ANDROID_BUILD_TOOLS: ${{ steps.vars.outputs.build-tools }}
+        ANDROID_NDK: ${{ steps.vars.outputs.ndk-version }}
+      run: |
+        sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --install \
+          "platform-tools" \
+          "platforms;android-${ANDROID_API_LEVEL}" \
+          "build-tools;${ANDROID_BUILD_TOOLS}" \
+          "ndk;${ANDROID_NDK}"
+
+    - name: Refresh Android environment variables and PATH
+      shell: bash
+      run: |
+        SDK_ROOT="${{ steps.vars.outputs.sdk-root }}"
+        NDK_ROOT="${{ steps.vars.outputs.ndk-root }}"
+        BUILD_TOOLS="${{ steps.vars.outputs.build-tools }}"
+
+        {
+          echo "ANDROID_HOME=${SDK_ROOT}"
+          echo "ANDROID_SDK_ROOT=${SDK_ROOT}"
+          echo "ANDROID_NDK_HOME=${NDK_ROOT}"
+          echo "ANDROID_NDK_ROOT=${NDK_ROOT}"
+        } >> "$GITHUB_ENV"
+
+        {
+          echo "${SDK_ROOT}/platform-tools"
+          echo "${SDK_ROOT}/cmdline-tools/latest/bin"
+          echo "${SDK_ROOT}/build-tools/${BUILD_TOOLS}"
+        } >> "$GITHUB_PATH"
+
+    - name: Verify Android SDK installation
+      shell: bash
+      env:
+        ANDROID_SDK_ROOT: ${{ steps.vars.outputs.sdk-root }}
+        ANDROID_API_LEVEL: ${{ steps.vars.outputs.api-level }}
+        ANDROID_BUILD_TOOLS: ${{ steps.vars.outputs.build-tools }}
+        ANDROID_NDK: ${{ steps.vars.outputs.ndk-version }}
+      run: |
+        echo "ANDROID_HOME=${ANDROID_HOME}"
+        echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}"
+        echo "ANDROID_NDK_HOME=${ANDROID_NDK_HOME}"
+        echo "ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT}"
+
+        which adb
+        which sdkmanager
+
+        adb version
+        sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --list_installed
+
+        test -x "${ANDROID_SDK_ROOT}/platform-tools/adb"
+        test -d "${ANDROID_SDK_ROOT}/platforms/android-${ANDROID_API_LEVEL}"
+        test -d "${ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS}"
+        test -d "${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # github-actions-common
 
 Repository contains set of reusable Github workflows which can be used in different repositories as utility stuff.
+
+## Available actions and workflows
+
+- [`defoldsdk` reusable workflow](./.github/workflows/defoldsdk.yml)
+- [`android` composite action](./.github/actions/android/README.md)


### PR DESCRIPTION
It turns out the other action we used, didn't actually retrieve ndk `r25b`, but instead downloaded r27 which broke our builds.